### PR TITLE
Don't store empty array (no meta values)

### DIFF
--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -159,9 +159,9 @@ class WP_Post_Meta_Revisioning {
 		// Save revisioned meta fields.
 		foreach ( $this->wp_post_revision_meta_keys() as $meta_key ) {
 			$meta_value = get_post_meta( $post_id, $meta_key );
-			
+
 			// Don't store an empty array indicating no meta values present.
-			if ( $meta_value === [] ) {
+			if ( array() === $meta_value ) {
 				continue;
 			}
 

--- a/wp-post-meta-revisions.php
+++ b/wp-post-meta-revisions.php
@@ -159,6 +159,11 @@ class WP_Post_Meta_Revisioning {
 		// Save revisioned meta fields.
 		foreach ( $this->wp_post_revision_meta_keys() as $meta_key ) {
 			$meta_value = get_post_meta( $post_id, $meta_key );
+			
+			// Don't store an empty array indicating no meta values present.
+			if ( $meta_value === [] ) {
+				continue;
+			}
 
 			/*
 			 * Use the underlying add_metadata() function vs add_post_meta()


### PR DESCRIPTION
Currently, with version 1, if there are no meta values for a given key, the `get_post_meta` function will return an empty array. This is because the function is configured to return all, and not just a single field.

We don't want to store this empty array, though!

If we were to upgrade/switch to the official version 2 of the plugin, this issue would go away automatically, since the approach to storing meta values has been changed.